### PR TITLE
Support blocking queue pop

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -352,9 +352,10 @@ module Resque
 
   # Pops a job off a queue. Queue name should be a string.
   #
-  # Returns a Ruby object.
+  # Returns the queue and the Ruby object that was popped, or nil.
   def pop(*queues, interval: 0)
-    decode(data_store.pop_from_queue(*queues, interval: interval))
+    queue, value = data_store.pop_from_queue(*queues, interval: interval)
+    return queue, decode(value)
   end
 
   # Returns an integer representing the size of a queue.
@@ -512,7 +513,7 @@ module Resque
   # precise name of a queue: case matters.
   #
   # This method is considered part of the `stable` API.
-  def reserve(*queues, interval: 5.0)
+  def reserve(*queues, interval: 0)
     return Job.reserve(*queues, interval: interval)
   end
 

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -353,8 +353,8 @@ module Resque
   # Pops a job off a queue. Queue name should be a string.
   #
   # Returns a Ruby object.
-  def pop(queue)
-    decode(data_store.pop_from_queue(queue))
+  def pop(*queues, interval: 0)
+    decode(data_store.pop_from_queue(*queues, interval: interval))
   end
 
   # Returns an integer representing the size of a queue.
@@ -512,8 +512,8 @@ module Resque
   # precise name of a queue: case matters.
   #
   # This method is considered part of the `stable` API.
-  def reserve(queue)
-    Job.reserve(queue)
+  def reserve(*queues, interval: 5.0)
+    return Job.reserve(*queues, interval: interval)
   end
 
   # Validates if the given klass could be a valid Resque job

--- a/lib/resque/data_store.rb
+++ b/lib/resque/data_store.rb
@@ -106,14 +106,15 @@ module Resque
         end
       end
 
-      # Pop whatever is on queue
+      # Pop whatever is on queue. Returns the queue name and the object if
+      # popped or nil.
       def pop_from_queue(*queues, interval: 0)
         if interval > 0
-          return @redis.blpop(queues.map { redis_key_for_queue(_1) }, interval)&.second
+          return @redis.blpop(queues.map { redis_key_for_queue(_1) }, interval)
         else
           return queues.detect do |queue|
             value = @redis.lpop(redis_key_for_queue(queue))
-            break value if !value.nil?
+            break [queue, value] if !value.nil?
           end
         end
       end

--- a/lib/resque/data_store.rb
+++ b/lib/resque/data_store.rb
@@ -109,8 +109,8 @@ module Resque
       # Pop whatever is on queue. Returns the queue name and the object if
       # popped or nil.
       def pop_from_queue(*queues, interval: 0)
-        if interval > 0
-          return @redis.blpop(queues.map { redis_key_for_queue(_1) }, interval)
+        if interval.to_i > 0
+          return @redis.blpop(queues.map { redis_key_for_queue(_1) }, interval.to_i)
         else
           return queues.detect do |queue|
             value = @redis.lpop(redis_key_for_queue(queue))

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -139,8 +139,8 @@ module Resque
 
     # Given a string queue name, returns an instance of Resque::Job
     # if any jobs are available. If not, returns nil.
-    def self.reserve(queue)
-      return unless payload = Resque.pop(queue)
+    def self.reserve(*queues, interval: 0)
+      return unless payload = Resque.pop(*queues, interval: interval)
       new(queue, payload)
     end
 

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -140,8 +140,9 @@ module Resque
     # Given a string queue name, returns an instance of Resque::Job
     # if any jobs are available. If not, returns nil.
     def self.reserve(*queues, interval: 0)
-      return unless payload = Resque.pop(*queues, interval: interval)
-      new(queue, payload)
+      queue, payload = Resque.pop(*queues, interval: interval)
+      return if !queue || !payload
+      return new(queue, payload)
     end
 
     # Attempts to perform the work represented by this job instance.

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -329,7 +329,7 @@ module Resque
 
     # Attempts to grab a job off one of the provided queues. Returns
     # nil if no job can be found.
-    def reserve(interval: 5.0)
+    def reserve(interval: 0)
       return Resque.reserve(*queues, interval: interval)
     rescue Exception => e
       log_with_severity :error, "Error reserving job: #{e.inspect}"

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -246,6 +246,14 @@ module Resque
       loop do
         break if shutdown?
 
+        # Wait until queues are populated. If queues is a glob and there are no
+        # queues defined yet, we can wait until the queues become defined in
+        # redis.
+        while queues.empty?
+          procline "Waiting for queues to be defined"
+          sleep 5.seconds
+        end
+
         unless work_one_job(interval: interval, &block)
           state_change
           break if interval.zero?

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -246,12 +246,10 @@ module Resque
       loop do
         break if shutdown?
 
-        unless work_one_job(&block)
+        unless work_one_job(interval: interval, &block)
           state_change
           break if interval.zero?
-          log_with_severity :debug, "Sleeping for #{interval} seconds"
           procline paused? ? "Paused" : "Waiting for #{queues.join(',')}"
-          sleep interval
         end
       end
 
@@ -264,9 +262,9 @@ module Resque
       run_hook :worker_exit
     end
 
-    def work_one_job(job = nil, &block)
+    def work_one_job(job = nil, interval: 0, &block)
       return false if paused?
-      return false unless job ||= reserve
+      return false unless job ||= reserve(interval: interval)
 
       working_on job
       procline "Processing #{job.queue} since #{Time.now.to_i} [#{job.payload_class_name}]"
@@ -331,16 +329,8 @@ module Resque
 
     # Attempts to grab a job off one of the provided queues. Returns
     # nil if no job can be found.
-    def reserve
-      queues.each do |queue|
-        log_with_severity :debug, "Checking #{queue}"
-        if job = Resque.reserve(queue)
-          log_with_severity :debug, "Found job on #{queue}"
-          return job
-        end
-      end
-
-      nil
+    def reserve(interval: 5.0)
+      return Resque.reserve(*queues, interval: interval)
     rescue Exception => e
       log_with_severity :error, "Error reserving job: #{e.inspect}"
       log_with_severity :error, e.backtrace.join("\n")


### PR DESCRIPTION
# Release Announcement

_Behind the Scenes_
* Support blocking Resque queue pop operations [ticket](https://linear.app/branch/issue/PLAT-718/fork-resque-to-use-blocking-calls) @<!-- -->mike

- [x] Release announcement note, Shortcut ticket and relevant stakeholders

# Summary

This is a quick (and somewhat dirty) blocking queue pop implementation or Resque. Instead of sleeping, it blocks on redis for the sleep interval.

- [x] Set primary reviewer as assignee

# Monitoring plan

- Check the resque queues dashboard. In queue times should drop but everything should continue to function without any errors or issues.

# Testing

## Manual Tests

- [x] Verify running the workers locally leads to expected results

Manual test loom: https://www.loom.com/share/8daf0ab4a9c344d987a2cff9c2782797

## Unit Tests

- No changes